### PR TITLE
lftp での WordPress メンテ表示対応 + マーカー処理の mtime 保存（差分転送の改善）

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ on:
 | `DEP_[BRANCH]_INCLUDE_FILE` | 例: `./.depinc.sh` | [include file](#include-file) のパスまたは URL |
 | `DEP_[BRANCH]_IGNORE_FILE` | 例: `./.depignore` | [ignore file](#ignore-file) のパスまたは URL。未指定時は[デフォルト](https://raw.githubusercontent.com/karappo/github-deploy/refs/heads/main/.depignore)を使用 |
 
+WordPress 用 include（`wordpress/`）を使う場合の追加変数:
+
+| 変数名 | 値 | 説明 |
+|:--|:--|:--|
+| `DEP_WP_DIR` | 例: `wp` | WP コアのディレクトリ（HOST_DIR からの相対）。`.maintenance` の設置先に使う。既定 `wp` |
+| `DEP_MAINTENANCE_MAX_MINUTES` | 例: `60` | デプロイ中のメンテ表示を維持する最大時間（分）。既定 `60`。WordPress の 10 分自動解除を避けつつ、teardown 失敗時の自動復帰上限にもなる |
+
 ## Include file
 
 同期の前後にカスタム処理を実行できるファイルです。
@@ -263,7 +270,7 @@ define('DB_HOST', 'localhost');
 | ディレクトリ | 用途 |
 |:--|:--|
 | `php/` | PHP サイト向け（htaccess・robots.txt・PHP ファイルの置換処理） |
-| `wordpress/` | WordPress 向け（PHP の置換処理 + デプロイ後のパーミッション設定） |
+| `wordpress/` | WordPress 向け（置換処理 + デプロイ中のメンテナンス表示 + パーミッション設定）。rsync(SSH) / lftp(FTP) 両対応。lftp ではメンテ表示のみ行いパーミッション設定は skip する |
 | `coreserver/` | CoreServer 向け（SSH 登録 + PHP の置換処理） |
 | `modx-tmpl/` | MODX 向けテンプレート（要カスタマイズ） |
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -209,6 +209,12 @@ else
   source "$DEP_INCLUDE_FILE"
 fi
 
+# teardown hook
+# include で on_teardown が定義されていれば、スクリプト終了時（成功・失敗・中断の
+# いずれでも）必ず実行する。同期失敗時は after_sync が呼ばれないため、メンテナンス
+# 表示の解除などの後始末をここで保証する。
+trap 'type on_teardown >/dev/null 2>&1 && on_teardown' EXIT
+
 do_sync
 
 exit 0

--- a/include-files/php/.depinc.sh
+++ b/include-files/php/.depinc.sh
@@ -2,21 +2,44 @@
 
 # for PHP website deploy
 
+# .htaccess / robots.txt / *.php に埋め込んだ環境別マーカーを除去する。
+#   #DEP_REMOTE_RM  / #DEP_<BRANCH>_RM   … apache(.htaccess) / robots.txt 用
+#   //DEP_REMOTE_RM / //DEP_<BRANCH>_RM  … php 用
+# REMOTE は全環境、<BRANCH> は対象ブランチ（GITHUB_REF_NAME を大文字化）でのみ除去。
+#
+# 【mtime を保つ理由】
+# sed -i は置換が無くてもファイルを書き直して mtime を更新する。全 .php を無条件に
+# sed -i すると、git-restore-mtime 等で安定させた mtime が毎回更新され、lftp mirror
+# が変更の無いファイルまで再送してしまう。そこで
+#   1) grep で実際にマーカーを含むファイルだけを対象にし、
+#   2) sed の前後で mtime を保存・復元する。
+# これにより未変更ファイルの再送を防ぎ、差分転送を効かせる。
+
+# 指定ファイルに sed をかけるが、mtime は元の値に復元する（GNU coreutils 前提）
+# usage: dep_sed_keep_mtime <file> <sed-expr> [<sed-expr> ...]
+dep_sed_keep_mtime(){
+  local f="$1"; shift
+  local ts; ts="$(stat -c %Y "$f")"
+  local args=(); local e
+  for e in "$@"; do args+=(-e "$e"); done
+  sed -i "${args[@]}" "$f"
+  touch -d "@$ts" "$f"
+}
+
 before_sync(){
+  local branch="${GITHUB_REF_NAME^^}"
 
-  # extension of backup files which are created before replacement
-  ext=".temp_bakup"
+  # .htaccess / robots.txt（# プレフィックス）
+  while IFS= read -r -d '' f; do
+    dep_sed_keep_mtime "$f" "s|#DEP_REMOTE_RM ||" "s|#DEP_${branch}_RM ||"
+  done < <(grep -rlZ --exclude-dir=.git --include='*.htaccess' --include='*robots.txt' \
+             -e "#DEP_REMOTE_RM " -e "#DEP_${branch}_RM " . 2>/dev/null)
 
-  # remove "DEP_XXX_RM "
-  find . -name "*.htaccess" -exec sed -i$ext "s|#DEP_REMOTE_RM ||" {} \;
-  find . -name "*.htaccess" -exec sed -i$ext "s|#DEP_${GITHUB_REF_NAME^^}_RM ||" {} \;
-  find . -name "*robots.txt" -exec sed -i$ext "s|#DEP_REMOTE_RM ||" {} \;
-  find . -name "*robots.txt" -exec sed -i$ext "s|#DEP_${GITHUB_REF_NAME^^}_RM ||" {} \;
-  find . -name "*.php" -exec sed -i$ext "s|//DEP_REMOTE_RM ||" {} \;
-  find . -name "*.php" -exec sed -i$ext "s|//DEP_${GITHUB_REF_NAME^^}_RM ||" {} \;
+  # *.php（// プレフィックス）
+  while IFS= read -r -d '' f; do
+    dep_sed_keep_mtime "$f" "s|//DEP_REMOTE_RM ||" "s|//DEP_${branch}_RM ||"
+  done < <(grep -rlZ --exclude-dir=.git --include='*.php' \
+             -e "//DEP_REMOTE_RM " -e "//DEP_${branch}_RM " . 2>/dev/null)
 
-  # delete backup files
-  find . -name "*$ext" -exec rm {} \;
-
-  return
+  return 0
 }

--- a/include-files/wordpress/.depinc.sh
+++ b/include-files/wordpress/.depinc.sh
@@ -1,89 +1,123 @@
 #!/bin/bash
 
-# for WordPress website deploy (need SSH)
-
-# ----------------------------------------------------------------------
-# メンテナンス表示について
+# for WordPress website deploy（rsync(SSH) / lftp(FTP) 両対応）
 #
-# 同期(rsync/lftp)中はファイルが不整合な状態になるため、WordPress 標準の
-# `.maintenance` ファイルを使ってデプロイ中だけメンテナンス画面を表示する。
-#   - before_sync : 同期開始前にリモートへ .maintenance を設置（メンテ ON）
-#   - after_sync  : 同期完了後にリモートから .maintenance を削除（メンテ OFF）
+# 機能:
+#  - デプロイ中だけ WordPress 標準の .maintenance を設置してメンテナンス画面を表示
+#    （同期中の不整合をユーザに見せない）。rsync(SSH) でも lftp(FTP) でも動作する。
+#  - .htaccess / robots.txt / *.php の #DEP_*_RM / //DEP_*_RM マーカーを除去（後述の
+#    通り mtime を保存して差分転送を維持）。
+#  - rsync の場合のみ、同期後にパーミッションを設定する（FTP では実施不可のため skip）。
+#
+# 必要に応じて調整する環境変数:
+#   DEP_WP_DIR                  WP コアのディレクトリ（HOST_DIR からの相対）。既定 "wp"
+#   DEP_MAINTENANCE_MAX_MINUTES メンテ表示を維持する最大時間（分）。既定 60
+#       .maintenance の $upgrading を「現在時刻 + この分数」に設定する。WordPress は
+#       $upgrading から 10 分でメンテを自動解除するため、time() のままだと長時間デプロイ
+#       の途中で解除されてしまう。未来時刻にすることで解除を防ぎつつ、万一 teardown が
+#       走らなかった場合でもこの時間で自動復帰する（永久ロック防止）。
 #
 # 【必須】.depignore に `.maintenance` を追加すること。
-#   rsync は --delete 付きで動作しており、ローカルに無いファイルはリモートから
-#   削除される。除外しておかないと設置した .maintenance が同期中に消えてしまう。
+#   mirror は --delete 付きで動作するため、除外しないと設置した .maintenance が同期中に
+#   削除されてしまう。
 #
-# 【注意1】WordPress コアは $upgrading から 10 分経過すると自動でメンテを解除する。
-#   10 分以上かかるデプロイでは途中で解除される点に留意。
-# 【注意2】同期が失敗すると deploy.sh は after_sync を実行せず終了するため、
-#   .maintenance が残りメンテ表示が継続する（半端な状態を晒さない利点もあるが、
-#   上記 10 分ルールで最終的には自動解除される）。
-#
-# WP コアの場所に合わせて MAINTENANCE_FILE のパスを調整すること。
-# このリポジトリの WordPress 構成ではコアが wp/ 配下にあるため wp/.maintenance。
-# ----------------------------------------------------------------------
-MAINTENANCE_FILE="$DEP_HOST_DIR/wp/.maintenance"
+# メンテ ON/OFF のタイミング:
+#   before_sync : 残骸を掃除 → .maintenance を設置（メンテ ON）
+#   on_teardown : .maintenance を削除（メンテ OFF）。deploy.sh の EXIT trap から呼ばれ、
+#                 同期の成功・失敗・中断いずれでも必ず実行される。
 
-# リモートでコマンドを実行するヘルパー（ポート指定の有無を吸収）
-maintenance_ssh(){
-  if [ "${DEP_PORT:+isexists}" = "isexists" ]; then
+DEP_WP_DIR="${DEP_WP_DIR:-wp}"
+_dep_maint_file="$DEP_HOST_DIR/$DEP_WP_DIR/.maintenance"
+
+# lftp をワンショット実行（FTPS 設定を吸収）
+_dep_lftp(){
+  local opt="set ftp:ssl-allow off;"
+  if [ "$DEP_FTPS" != "no" ]; then
+    opt="set ftp:ssl-auth TLS;set ftp:ssl-force true;set ftp:ssl-protect-data yes;"
+  fi
+  lftp -u "$DEP_USER,$DEP_PASSWORD" -e "$opt $1;bye" "$DEP_HOST"
+}
+
+# ssh をワンショット実行（ポート指定を吸収）
+_dep_ssh(){
+  if [ "${DEP_PORT:+x}" = "x" ]; then
     ssh "$DEP_USER@$DEP_HOST" -p "$DEP_PORT" "$1"
   else
     ssh "$DEP_USER@$DEP_HOST" "$1"
   fi
 }
 
+maintenance_on(){
+  local ts=$(( $(date +%s) + ${DEP_MAINTENANCE_MAX_MINUTES:-60} * 60 ))
+  local content="<?php \$upgrading = $ts; ?>"
+  if [ "$DEP_COMMAND" = "lftp" ]; then
+    local tmp; tmp="$(mktemp)"
+    printf '%s' "$content" > "$tmp"
+    _dep_lftp "put \"$tmp\" -o \"$_dep_maint_file\""
+    rm -f "$tmp"
+  else
+    _dep_ssh "printf '%s' '$content' > \"$_dep_maint_file\""
+  fi
+}
+
+maintenance_off(){
+  if [ "$DEP_COMMAND" = "lftp" ]; then
+    _dep_lftp "rm -f \"$_dep_maint_file\"" 2>/dev/null || true
+  else
+    _dep_ssh "rm -f \"$_dep_maint_file\"" 2>/dev/null || true
+  fi
+}
+
+# 指定ファイルに sed をかけるが mtime は元の値に復元する（GNU coreutils 前提）
+# sed -i は置換が無くてもファイルを書き直して mtime を更新するため、未変更ファイルが
+# mirror で再送されてしまう。grep で対象を絞り、mtime を保存して差分転送を維持する。
+dep_sed_keep_mtime(){
+  local f="$1"; shift
+  local t; t="$(stat -c %Y "$f")"
+  local args=(); local e
+  for e in "$@"; do args+=(-e "$e"); done
+  sed -i "${args[@]}" "$f"
+  touch -d "@$t" "$f"
+}
+
 before_sync(){
+  # 直前の失敗等で残った .maintenance を掃除してからメンテ ON
+  maintenance_off
+  maintenance_on
 
-  # メンテナンス表示 ON（同期開始前にリモートへ .maintenance を設置）
-  maintenance_ssh "printf '%s' '<?php \$upgrading = time(); ?>' > $MAINTENANCE_FILE"
+  local branch="${GITHUB_REF_NAME^^}"
 
-  # extension of backup files which are created before replacement
-  ext=".temp_bakup"
+  # .htaccess / robots.txt（# プレフィックス）
+  while IFS= read -r -d '' f; do
+    dep_sed_keep_mtime "$f" "s|#DEP_REMOTE_RM ||" "s|#DEP_${branch}_RM ||"
+  done < <(grep -rlZ --exclude-dir=.git --include='*.htaccess' --include='*robots.txt' \
+             -e "#DEP_REMOTE_RM " -e "#DEP_${branch}_RM " . 2>/dev/null)
 
-  # remove "DEP_XXX_RM "
-  find . -name "*.htaccess" -exec sed -i$ext "s|#DEP_REMOTE_RM ||" {} \;
-  find . -name "*.htaccess" -exec sed -i$ext "s|#DEP_${GITHUB_REF_NAME^^}_RM ||" {} \;
-  find . -name "*robots.txt" -exec sed -i$ext "s|#DEP_REMOTE_RM ||" {} \;
-  find . -name "*robots.txt" -exec sed -i$ext "s|#DEP_${GITHUB_REF_NAME^^}_RM ||" {} \;
-  find . -name "*.php" -exec sed -i$ext "s|//DEP_REMOTE_RM ||" {} \;
-  find . -name "*.php" -exec sed -i$ext "s|//DEP_${GITHUB_REF_NAME^^}_RM ||" {} \;
+  # *.php（// プレフィックス）
+  while IFS= read -r -d '' f; do
+    dep_sed_keep_mtime "$f" "s|//DEP_REMOTE_RM ||" "s|//DEP_${branch}_RM ||"
+  done < <(grep -rlZ --exclude-dir=.git --include='*.php' \
+             -e "//DEP_REMOTE_RM " -e "//DEP_${branch}_RM " . 2>/dev/null)
 
-  # delete backup files
-  find . -name "*$ext" -exec rm {} \;
-
-  return
+  return 0
 }
 
 after_sync(){
-  sh -c "echo '
-cd '${DEP_HOST_DIR}'
+  # パーミッション設定は SSH 前提。lftp(FTP) では実施できないため skip。
+  [ "$DEP_COMMAND" = "lftp" ] && return 0
 
-echo ''
-echo --- Set Permissions -------------
-find ./ -type d -exec chmod 705 {} \;
-find ./ -type f -exec chmod 604 {} \;
-find ./ -name .htaccess -exec chmod 604 {} \;
-find ./ -name wp-config.php -exec chmod 400 {} \;
-echo ---------------------------------
-echo ''
-echo --- Check Permissions -----------
-stat -f \"%N %Mp%Lp\" .htaccess
-stat -f \"%N %Mp%Lp\" wp/wp-config.php
-stat -f \"%N %Mp%Lp\" wp/wp-content/plugins
-stat -f \"%N %Mp%Lp\" wp/wp-content/themes
-stat -f \"%N %Mp%Lp\" wp/wp-content/uploads
-echo ---------------------------------
-echo ''
-' > script.sh"
-  if [ "${DEP_PORT:+isexists}" = "isexists" ]; then
-    ssh $DEP_USER@$DEP_HOST -p $DEP_PORT 'bash -s' < script.sh
-  else
-    ssh $DEP_USER@$DEP_HOST 'bash -s' < script.sh
-  fi
-  rm -f script.sh
+  _dep_ssh "
+    cd '$DEP_HOST_DIR'
+    echo '--- Set Permissions -------------'
+    find ./ -type d -exec chmod 705 {} \;
+    find ./ -type f -exec chmod 604 {} \;
+    find ./ -name .htaccess -exec chmod 604 {} \;
+    find ./ -name wp-config.php -exec chmod 400 {} \;
+    echo '---------------------------------'
+  "
+}
 
-  # メンテナンス表示 OFF（同期完了・パーミッション設定後に .maintenance を削除）
-  maintenance_ssh "rm -f $MAINTENANCE_FILE"
+# deploy.sh の EXIT trap から呼ばれ、成功・失敗・中断いずれでもメンテを解除する
+on_teardown(){
+  maintenance_off
 }


### PR DESCRIPTION
## 背景

福永紙工サイト（lftp/FTP デプロイ・SSH不可）の自動デプロイ導入中に、以下2つの実運用課題が判明したため改善します。

1. **未変更ファイルの再送**: `git-restore-mtime` で mtime を安定化しても、include の `before_sync` が全 .php を無条件に `sed -i` するため mtime が毎回更新され、`lftp mirror` が変更の無い .php（実測で約2,244件）を毎回再送していた。
2. **FTP 専用サーバでメンテ表示が使えない**: 既存 `wordpress/.depinc.sh` はメンテ表示・パーミッション設定が SSH 前提で、FTP のみのサーバでは利用できなかった。

## 変更内容

### 1. include の sed で mtime を保存（`php/` `wordpress/`）
- `grep` で実際にマーカー（`#DEP_*_RM` / `//DEP_*_RM`）を含むファイルだけを対象化。
- `sed` の前後で mtime を保存・復元（`stat -c %Y` → `touch -d @<epoch>`）。
- 挙動（マーカー除去結果）は従来と同一。未変更ファイルの再送が無くなり差分転送が効く。

### 2. `wordpress/.depinc.sh` を rsync(SSH) / lftp(FTP) 両対応に
- メンテ表示の `.maintenance` 設置/削除を `$DEP_COMMAND` で分岐（rsync→ssh、lftp→lftp の put/rm）。
- パーミッション設定は SSH 前提のため lftp では skip。
- `DEP_WP_DIR`（`.maintenance` の設置先, 既定 `wp`）を追加。

### 3. `deploy.sh` に EXIT trap の teardown フック
- include が `on_teardown` を定義していれば、同期の**成功・失敗・中断いずれでも**必ず実行（`trap ... EXIT`）。
- これでメンテ解除を確実化。同期失敗時に after_sync が呼ばれずメンテが残る問題を解消。
- あわせて `.maintenance` の `$upgrading` を**未来時刻**（既定60分, `DEP_MAINTENANCE_MAX_MINUTES`）に設定。WP の10分自動解除による長時間デプロイ途中での解除を防ぎつつ、teardown が万一走らなくてもこの時間で**自動復帰**（永久ロック防止）。

## 互換性
- rsync(SSH) 既存利用は従来通り動作（メンテ ON/OFF の削除タイミングが after_sync → on_teardown に移動、`$upgrading` が time() → 未来時刻に変更）。
- `.depignore` に `.maintenance` を含めること（既存ドキュメント通り）。

## 検証状況
- 福永（lftp）で **1（mtime保存）** を先行適用予定（同等の独自 include で挙動確認中）。サーバが mtime を保持することは実測済み（非PHPファイルが差分スキップされることを確認）。
- **2・3（メンテ表示/teardown）** は本 PR で初投入のため、マージ前に rsync / lftp 双方での動作確認を推奨します。特に lftp の `.maintenance` put/rm と、失敗時の teardown 動作。

## 備考
- mtime 保存は GNU coreutils（`stat -c` / `touch -d @`）前提です（ubuntu-latest ランナー想定。既存 include も GNU 前提の `sed -i` を使用）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
